### PR TITLE
Fix NullPointerException AstValue.java(247)

### DIFF
--- a/impl/src/main/java/com/sun/el/parser/AstValue.java
+++ b/impl/src/main/java/com/sun/el/parser/AstValue.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2012 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2020 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -244,7 +244,7 @@ public final class AstValue extends SimpleNode {
             if (ctx.isPropertyResolved()) {
                 value = targetValue;
             } else {
-                if (value != null || targetType.isPrimitive()) {
+                if (value != null || (targetType != null && targetType.isPrimitive())) {
                     value = ELSupport.coerceToType(value, targetType);
                 }
             }


### PR DESCRIPTION
It fixes:
Caused by: java.lang.NullPointerException 
	at com.sun.el.parser.AstValue.setValue(AstValue.java:247) 
	at com.sun.el.ValueExpressionImpl.setValue(ValueExpressionImpl.java:294) 
	at oracle.apps.hcm.hcmHomePage.publicUi.dc.facetedSearch.util.FacetedSearchUtility.setEL(FacetedSearchUtility.java:413) 
	at oracle.apps.hcm.hcmHomePage.publicUi.dc.facetedSearch.facets.SelectLinkFacet.populateDefaultModelValues(SelectLinkFacet.java:228)